### PR TITLE
Tighten up the workflow permissions

### DIFF
--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -8,13 +8,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   checksums:
     name: ${{ inputs.tag }}
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     steps:
       - name: Prepare tag name

--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -12,13 +12,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   compare:
     name: "${{ inputs.source }}"
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     steps:
       - name: Download canonical source artifact

--- a/.github/workflows/hashes.yml
+++ b/.github/workflows/hashes.yml
@@ -8,13 +8,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zip:
     name: "${{ inputs.tag }} zip"
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     steps:
       - name: Prepare tag name
@@ -43,9 +43,11 @@ jobs:
       - name: Check the sha1 hash
         run: |
           echo "$(cat package.zip.sha1) package.zip" | sha1sum -c -
+
   tar:
     name: "${{ inputs.tag }} tar"
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     steps:
       - name: Prepare tag name

--- a/.github/workflows/offer.yml
+++ b/.github/workflows/offer.yml
@@ -8,13 +8,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   verify:
     name: ${{ inputs.tag }}
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     steps:
       - name: Prepare tag name

--- a/.github/workflows/rave.yml
+++ b/.github/workflows/rave.yml
@@ -32,13 +32,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   versions:
     name: Determine branch numbers
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       versions: ${{ steps.fetch.outputs.versions }}
     steps:
@@ -68,8 +68,10 @@ jobs:
         with:
           name: offers
           path: offers.json
+
   reproduce:
     name: "Reproduce ${{ matrix.tag }}"
+    permissions: {}
     needs:
       - versions
     strategy:
@@ -88,8 +90,10 @@ jobs:
     with:
       tag: ${{ matrix.tag }}
       source: ${{ matrix.source }}
+
   compare:
     name: "Compare ${{ matrix.tag }}"
+    permissions: {}
     needs:
       - reproduce
       - versions
@@ -108,8 +112,10 @@ jobs:
     with:
       tag: ${{ matrix.tag }}
       source: ${{ matrix.source }}
+
   offers:
     name: ${{ matrix.label }}
+    permissions: {}
     needs:
       - versions
     strategy:
@@ -121,8 +127,11 @@ jobs:
     uses: ./.github/workflows/offer.yml
     with:
       tag: ${{ matrix.tag }}
+
   verify-packages:
     name: "Verify ${{ matrix.tag }} packages"
+    permissions:
+      contents: read
     needs:
       - reproduce
       - versions
@@ -151,8 +160,11 @@ jobs:
     with:
       tag: ${{ matrix.tag }}
       package: ${{ matrix.package }}
+
   verify-latest-package:
     name: "Verify ${{ matrix.tag }} packages"
+    permissions:
+      contents: read
     needs:
       - reproduce
     strategy:
@@ -167,8 +179,10 @@ jobs:
     with:
       tag: ${{ matrix.tag }}
       package: ${{ matrix.package }}
+
   verify-hashes:
     name: ${{ matrix.label }}
+    permissions: {}
     needs:
       - versions
     strategy:
@@ -180,8 +194,10 @@ jobs:
     uses: ./.github/workflows/hashes.yml
     with:
       tag: ${{ matrix.tag }}
+
   verify-checksums:
     name: ${{ matrix.label }}
+    permissions: {}
     needs:
       - versions
     strategy:

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -12,13 +12,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   reproduce:
     name: "${{ inputs.source }}"
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     steps:
       - name: Prepare tag name

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,13 +12,14 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   verify:
     name: "${{ inputs.package }}"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - name: Prepare tag name


### PR DESCRIPTION
My preference is to be explicit about permissions at both the workflow level and the job level.