### PR TITLE
Disable the Node cache

### DIFF
--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -77,7 +77,6 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
         with:
           node-version-file: .nvmrc
-          cache: npm
 
       - name: Log debug information
         run: | #shell


### PR DESCRIPTION
Something is up with the Node cache. [Jobs since 3PM GMT yesterday](https://github.com/johnbillion/rave-wordpress/actions/workflows/rave.yml) are timing out due to the cache server not responding.

> Warning: Failed to restore: getCacheEntry failed: connect ETIMEDOUT 20.246.192.124:443

[No caches have been stored for Node](https://github.com/johnbillion/rave-wordpress/actions/caches). Let's disable caching to see if it gets things moving again.