### PR TITLE
Add retry mechanism for downloads with 3 attempts and 20s delay

### DIFF
--- a/.github/actions/download-with-retry/action.yml
+++ b/.github/actions/download-with-retry/action.yml
@@ -1,0 +1,37 @@
+name: Download with retry
+description: Downloads a file with retry logic (3 attempts, 20s delay)
+
+inputs:
+  url:
+    description: URL to download from
+    required: true
+  output:
+    description: Output filename
+    required: true
+  user-agent:
+    description: User agent string
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download with retry
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          echo "Attempt $attempt to download from ${{ inputs.url }}"
+          if wget --output-document="${{ inputs.output }}" "${{ inputs.url }}" \
+            --user-agent="${{ inputs.user-agent }}"; then
+            echo "Download successful on attempt $attempt"
+            exit 0
+          else
+            echo "Download failed on attempt $attempt"
+            if [ $attempt -lt 3 ]; then
+              echo "Waiting 20 seconds before retry..."
+              sleep 20
+            else
+              echo "All download attempts failed"
+              exit 1
+            fi
+          fi
+        done

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Get zip file from GitHub
         if: inputs.package == 'github-zip'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -130,7 +130,7 @@ jobs:
 
       - name: Get zip file from wordpress.org
         if: inputs.package == 'wordpress.org-zip' && inputs.tag != 'latest'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -144,7 +144,7 @@ jobs:
 
       - name: Get tar file from wordpress.org
         if: inputs.package == 'wordpress.org-tar' && inputs.tag != 'latest'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.tar.gz
@@ -159,7 +159,7 @@ jobs:
 
       - name: Get latest zip file from wordpress.org
         if: inputs.package == 'wordpress.org-zip' && inputs.tag == 'latest'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: https://wordpress.org/latest.zip
           output: package.zip
@@ -173,7 +173,7 @@ jobs:
 
       - name: Get latest tar file from wordpress.org
         if: inputs.package == 'wordpress.org-tar' && inputs.tag == 'latest'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: https://wordpress.org/latest.tar.gz
           output: package.tar.gz
@@ -188,7 +188,7 @@ jobs:
 
       - name: Get zip file from downloads.wordpress.org
         if: inputs.package == 'downloads.wordpress.org-zip'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -202,7 +202,7 @@ jobs:
 
       - name: Get tar file from downloads.wordpress.org
         if: inputs.package == 'downloads.wordpress.org-tar'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.tar.gz
@@ -217,7 +217,7 @@ jobs:
 
       - name: Get zip file from downloads.w.org
         if: inputs.package == 'downloads.w.org-zip'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -231,7 +231,7 @@ jobs:
 
       - name: Get tar file from downloads.w.org
         if: inputs.package == 'downloads.w.org-tar'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.tar.gz
@@ -246,7 +246,7 @@ jobs:
 
       - name: Download zip from build.trac.wordpress.org
         if: inputs.package == 'build.trac.wordpress.org'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -274,7 +274,7 @@ jobs:
 
       - name: Download zip from core-updates.wpengine.com
         if: inputs.package == 'wpengine-zip'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -288,7 +288,7 @@ jobs:
 
       - name: Download zip from api.aspirecloud.net
         if: inputs.package == 'aspirecloud-zip'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip
@@ -302,7 +302,7 @@ jobs:
 
       - name: Download zip from FAIR
         if: inputs.package == 'fair-zip'
-        uses: ./.github/actions/download-with-retry
+        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@add-retry-mechanism
         with:
           url: ${{ env.PACKAGE_URL }}
           output: package.zip

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -114,105 +114,149 @@ jobs:
 
       - name: Get zip file from GitHub
         if: inputs.package == 'github-zip'
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract GitHub zip
+        if: inputs.package == 'github-zip'
         env:
           TAG: ${{ steps.tag.outputs.short }}
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv "wordpress/WordPress-${TAG}" package
 
       - name: Get zip file from wordpress.org
         if: inputs.package == 'wordpress.org-zip' && inputs.tag != 'latest'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract wordpress.org zip
+        if: inputs.package == 'wordpress.org-zip' && inputs.tag != 'latest'
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
       - name: Get tar file from wordpress.org
         if: inputs.package == 'wordpress.org-tar' && inputs.tag != 'latest'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.tar.gz
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract wordpress.org tar
+        if: inputs.package == 'wordpress.org-tar' && inputs.tag != 'latest'
         run: | #shell
-          wget --output-document=package.tar.gz "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           mkdir wordpress
           tar -xzf package.tar.gz -C wordpress
           mv wordpress/wordpress package
 
       - name: Get latest zip file from wordpress.org
         if: inputs.package == 'wordpress.org-zip' && inputs.tag == 'latest'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: https://wordpress.org/latest.zip
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract latest wordpress.org zip
+        if: inputs.package == 'wordpress.org-zip' && inputs.tag == 'latest'
         run: | #shell
-          wget --output-document=package.zip "https://wordpress.org/latest.zip" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
       - name: Get latest tar file from wordpress.org
         if: inputs.package == 'wordpress.org-tar' && inputs.tag == 'latest'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: https://wordpress.org/latest.tar.gz
+          output: package.tar.gz
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract latest wordpress.org tar
+        if: inputs.package == 'wordpress.org-tar' && inputs.tag == 'latest'
         run: | #shell
-          wget --output-document=package.tar.gz "https://wordpress.org/latest.tar.gz" \
-            --user-agent="WordPress/${TAG}"
           mkdir wordpress
           tar -xzf package.tar.gz -C wordpress
           mv wordpress/wordpress package
 
       - name: Get zip file from downloads.wordpress.org
         if: inputs.package == 'downloads.wordpress.org-zip'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract downloads.wordpress.org zip
+        if: inputs.package == 'downloads.wordpress.org-zip'
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
       - name: Get tar file from downloads.wordpress.org
         if: inputs.package == 'downloads.wordpress.org-tar'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.tar.gz
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract downloads.wordpress.org tar
+        if: inputs.package == 'downloads.wordpress.org-tar'
         run: | #shell
-          wget --output-document=package.tar.gz "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           mkdir wordpress
           tar -xzf package.tar.gz -C wordpress
           mv wordpress/wordpress package
 
       - name: Get zip file from downloads.w.org
         if: inputs.package == 'downloads.w.org-zip'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract downloads.w.org zip
+        if: inputs.package == 'downloads.w.org-zip'
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
       - name: Get tar file from downloads.w.org
         if: inputs.package == 'downloads.w.org-tar'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.tar.gz
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract downloads.w.org tar
+        if: inputs.package == 'downloads.w.org-tar'
         run: | #shell
-          wget --output-document=package.tar.gz "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           mkdir wordpress
           tar -xzf package.tar.gz -C wordpress
           mv wordpress/wordpress package
 
       - name: Download zip from build.trac.wordpress.org
         if: inputs.package == 'build.trac.wordpress.org'
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract build.trac.wordpress.org zip
+        if: inputs.package == 'build.trac.wordpress.org'
         env:
           TAG: ${{ steps.tag.outputs.short }}
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv "wordpress/${TAG}" package
 
@@ -230,31 +274,43 @@ jobs:
 
       - name: Download zip from core-updates.wpengine.com
         if: inputs.package == 'wpengine-zip'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract wpengine zip
+        if: inputs.package == 'wpengine-zip'
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
       - name: Download zip from api.aspirecloud.net
         if: inputs.package == 'aspirecloud-zip'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract aspirecloud zip
+        if: inputs.package == 'aspirecloud-zip'
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
       - name: Download zip from FAIR
         if: inputs.package == 'fair-zip'
-        env:
-          TAG: ${{ steps.tag.outputs.short }}
+        uses: ./.github/actions/download-with-retry
+        with:
+          url: ${{ env.PACKAGE_URL }}
+          output: package.zip
+          user-agent: WordPress/${{ steps.tag.outputs.short }}
+
+      - name: Extract FAIR zip
+        if: inputs.package == 'fair-zip'
         run: | #shell
-          wget --output-document=package.zip "$PACKAGE_URL" \
-            --user-agent="WordPress/${TAG}"
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ The GitHub Actions workflow runs once an hour. It verifies the latest version in
 * WordPress 6.8
 * WordPress 6.7
 
-_Note:_ Due to request rate limiting on wordpress.org, the `core.trac.wordpress.org` source and the `build.trac.wordpress.org` package are only verified for the most recent branch. All other sources and packages are verified for the three most recent branches.
+_Note:_ Due to request rate limiting on wordpress.org, the `core.trac.wordpress.org` source and the `build.trac.wordpress.org` package are only verified for the most recent branch.
 
 ## Why test the official package?
 


### PR DESCRIPTION
## Summary
- Create reusable composite action for download retries (3 attempts, 20s delay)
- Apply retry logic to all zip/tar download steps to handle 500 server errors
- Separate download and extraction steps for better workflow clarity

## Test plan
- [ ] Verify all download steps use the new composite action
- [ ] Test retry mechanism works when servers return 500 errors
- [ ] Ensure CI workflows complete successfully
- [ ] Confirm aspirecloud and other API downloads are more reliable

🤖 Generated with [Claude Code](https://claude.ai/code)