### PR TITLE
Generate attestations for packages

### DIFF
--- a/.github/workflows/rave.yml
+++ b/.github/workflows/rave.yml
@@ -173,6 +173,8 @@ jobs:
     name: ${{ matrix.label }}
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     needs:
       - reproduce
       - versions
@@ -206,6 +208,8 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' }}
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     needs:
       - reproduce
     strategy:

--- a/.github/workflows/rave.yml
+++ b/.github/workflows/rave.yml
@@ -197,32 +197,13 @@ jobs:
           - roots-wordpress-full
           - johnpbloch-wordpress
           - build.trac.wordpress.org
+        tag:
+          - ${{ needs.versions.outputs.version }}
+        include: ${{ github.event_name != 'workflow_dispatch' && fromJson('[{"label":"Verify latest packages","package":"wordpress.org-zip","tag":"latest"},{"label":"Verify latest packages","package":"wordpress.org-tar","tag":"latest"}]') || fromJson('[]') }}
       fail-fast: false
     uses: ./.github/workflows/verify.yml
     with:
-      tag: ${{ needs.versions.outputs.version }}
-      package: ${{ matrix.package }}
-
-  verify-latest-package:
-    name: ${{ matrix.label }}
-    if: ${{ github.event_name != 'workflow_dispatch' }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    needs:
-      - reproduce
-    strategy:
-      matrix:
-        label:
-          - Verify latest packages
-        package:
-          - wordpress.org-zip
-          - wordpress.org-tar
-      fail-fast: false
-    uses: ./.github/workflows/verify.yml
-    with:
-      tag: 'latest'
+      tag: ${{ matrix.tag }}
       package: ${{ matrix.package }}
 
   verify-hashes:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -489,3 +489,13 @@ jobs:
           subject-path: ${{ steps.package-check.outputs.package_file }}
           predicate-type: 'https://in-toto.io/attestation/release/v0.1'
           predicate-path: 'release-predicate.json'
+
+      - name: Verify attestation
+        if: steps.package-check.outputs.package_file != 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
+        run: |
+          echo "Verifying attestation for ${PACKAGE_FILE}..."
+          gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress
+          echo "✅ Attestation verified successfully for ${PACKAGE_FILE}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,7 +23,10 @@ jobs:
   verify:
     name: "${{ inputs.package }}"
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -424,8 +424,23 @@ jobs:
             echo "package_file=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate release predicate
+      - name: Check for existing attestation
         if: steps.package-check.outputs.package_file != 'false'
+        id: attestation-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
+        run: |
+          if gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress; then
+            echo "Attestation already exists for ${PACKAGE_FILE}"
+            echo "attestation_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No attestation found for ${PACKAGE_FILE}, will create one"
+            echo "attestation_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release predicate
+        if: steps.package-check.outputs.package_file != 'false' && steps.attestation-check.outputs.attestation_exists == 'false'
         env:
           TAG: ${{ steps.tag.outputs.short }}
           PACKAGE: ${{ inputs.package }}
@@ -468,8 +483,8 @@ jobs:
           echo "Generated release predicate for ${PACKAGE_FILE}"
 
       - name: Generate attestation
-        if: steps.package-check.outputs.package_file != 'false'
-        uses: actions/attest@v2.4.0
+        if: steps.package-check.outputs.package_file != 'false' && steps.attestation-check.outputs.attestation_exists == 'false'
+        uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
         with:
           subject-path: ${{ steps.package-check.outputs.package_file }}
           predicate-type: 'https://in-toto.io/attestation/release/v0.1'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -442,7 +442,6 @@ jobs:
         if: steps.package-check.outputs.package_file != 'false' && steps.attestation-check.outputs.attestation_exists == 'false'
         env:
           TAG: ${{ steps.tag.outputs.short }}
-          PACKAGE: ${{ inputs.package }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
           PACKAGE_EXTENSION: ${{ steps.package-check.outputs.package_extension }}
         run: | #shell
@@ -466,7 +465,7 @@ jobs:
             ],
             "predicateType": "https://in-toto.io/attestation/release/v0.1",
             "predicate": {
-              "purl": "pkg:rave/${PACKAGE}/wordpress@${TAG}",
+              "purl": "pkg:rave/wordpress@${TAG}",
               "metadata": {
                 "releaseNotes": "WordPress ${TAG}",
                 "vcs": {

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -415,7 +415,7 @@ jobs:
 
       - name: Check for package files
         id: package-check
-        run: |
+        run: | #shell
           if [ -f "package.zip" ]; then
             echo "package_file=package.zip" >> "$GITHUB_OUTPUT"
           elif [ -f "package.tar.gz" ]; then
@@ -430,7 +430,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
-        run: |
+        run: | #shell
           if gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress; then
             echo "Attestation already exists for ${PACKAGE_FILE}"
             echo "attestation_exists=true" >> "$GITHUB_OUTPUT"
@@ -445,7 +445,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.short }}
           PACKAGE: ${{ inputs.package }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
-        run: |
+        run: | #shell
           # Generate SHA256 of package file
           PACKAGE_SHA256=$(sha256sum "${PACKAGE_FILE}" | cut -d' ' -f1)
 
@@ -480,8 +480,6 @@ jobs:
           }
           EOF
 
-          echo "Generated release predicate for ${PACKAGE_FILE}"
-
       - name: Generate attestation
         if: steps.package-check.outputs.package_file != 'false' && steps.attestation-check.outputs.attestation_exists == 'false'
         uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
@@ -495,7 +493,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
-        run: |
-          echo "Verifying attestation for ${PACKAGE_FILE}..."
+        run: | #shell
           gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress
-          echo "✅ Attestation verified successfully for ${PACKAGE_FILE}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -342,6 +342,25 @@ jobs:
           mv vendor/johnpbloch/wordpress-core package
           rm package/composer.json
 
+      - name: Check for package files
+        id: package-check
+        run: | #shell
+          if [ -f "package.zip" ]; then
+            echo "package_file=package.zip" >> "$GITHUB_OUTPUT"
+          elif [ -f "package.tar.gz" ]; then
+            echo "package_file=package.tar.gz" >> "$GITHUB_OUTPUT"
+          else
+            echo "package_file=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload artifact
+        if: steps.package-check.outputs.package_file != 'false'
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # 4.5.0
+        with:
+          name: wordpress-${{ steps.tag.outputs.long }}-${{ inputs.package }}
+          path: ${{ steps.package-check.outputs.package_file }}
+          if-no-files-found: error
+
       - name: Handle anomalies with build files in TT and TT1
         if: inputs.package == 'github-zip' || inputs.package == 'build.trac.wordpress.org'
         run: | #shell
@@ -415,17 +434,6 @@ jobs:
         if: env.PACKAGE_INCLUDES_AKISMET == 'true'
         run: | #shell
           diff --strip-trailing-cr --recursive --color=always akismet-source akismet-package
-
-      - name: Check for package files
-        id: package-check
-        run: | #shell
-          if [ -f "package.zip" ]; then
-            echo "package_file=package.zip" >> "$GITHUB_OUTPUT"
-          elif [ -f "package.tar.gz" ]; then
-            echo "package_file=package.tar.gz" >> "$GITHUB_OUTPUT"
-          else
-            echo "package_file=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Check for existing attestation
         if: steps.package-check.outputs.package_file != 'false'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -488,6 +488,7 @@ jobs:
         uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
         with:
           subject-path: ${{ steps.package-check.outputs.package_file }}
+          subject-name: '${{ inputs.package }}/wordpress@${{ steps.tag.outputs.short }}'
           predicate-type: 'https://in-toto.io/attestation/release/v0.1'
           predicate-path: 'release-predicate.json'
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -434,7 +434,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
         run: | #shell
-          if gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress; then
+          if gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress --predicate-type "https://in-toto.io/attestation/release/v0.1"; then
             echo "Attestation already exists for ${PACKAGE_FILE}"
             echo "attestation_exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -497,4 +497,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
         run: | #shell
-          gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress
+          gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress --predicate-type "https://in-toto.io/attestation/release/v0.1"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,11 +29,6 @@ jobs:
       attestations: write
     timeout-minutes: 10
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-
       - name: Prepare tag name
         id: tag
         uses: johnbillion/rave-wordpress/.github/actions/prepare-tag-name@trunk
@@ -342,25 +337,6 @@ jobs:
           mv vendor/johnpbloch/wordpress-core package
           rm package/composer.json
 
-      - name: Check for package files
-        id: package-check
-        run: | #shell
-          if [ -f "package.zip" ]; then
-            echo "package_file=package.zip" >> "$GITHUB_OUTPUT"
-          elif [ -f "package.tar.gz" ]; then
-            echo "package_file=package.tar.gz" >> "$GITHUB_OUTPUT"
-          else
-            echo "package_file=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload artifact
-        if: steps.package-check.outputs.package_file != 'false'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # 4.5.0
-        with:
-          name: wordpress-${{ steps.tag.outputs.long }}-${{ inputs.package }}
-          path: ${{ steps.package-check.outputs.package_file }}
-          if-no-files-found: error
-
       - name: Handle anomalies with build files in TT and TT1
         if: inputs.package == 'github-zip' || inputs.package == 'build.trac.wordpress.org'
         run: | #shell
@@ -435,6 +411,19 @@ jobs:
         run: | #shell
           diff --strip-trailing-cr --recursive --color=always akismet-source akismet-package
 
+      - name: Check for package files
+        id: package-check
+        run: | #shell
+          if [ -f "package.zip" ]; then
+            echo "package_file=package.zip" >> "$GITHUB_OUTPUT"
+            echo "package_extension=zip" >> "$GITHUB_OUTPUT"
+          elif [ -f "package.tar.gz" ]; then
+            echo "package_file=package.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "package_extension=tar.gz" >> "$GITHUB_OUTPUT"
+          else
+            echo "package_file=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for existing attestation
         if: steps.package-check.outputs.package_file != 'false'
         id: attestation-check
@@ -443,10 +432,10 @@ jobs:
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
         run: | #shell
           if gh attestation verify "${PACKAGE_FILE}" --repo johnbillion/rave-wordpress --predicate-type "https://in-toto.io/attestation/release/v0.1"; then
-            echo "Attestation already exists for ${PACKAGE_FILE}"
+            echo "Attestation already exists"
             echo "attestation_exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No attestation found for ${PACKAGE_FILE}, will create one"
+            echo "No attestation found, will create one"
             echo "attestation_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -456,6 +445,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.short }}
           PACKAGE: ${{ inputs.package }}
           PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
+          PACKAGE_EXTENSION: ${{ steps.package-check.outputs.package_extension }}
         run: | #shell
           # Generate SHA256 of package file
           PACKAGE_SHA256=$(sha256sum "${PACKAGE_FILE}" | cut -d' ' -f1)
@@ -469,7 +459,7 @@ jobs:
             "_type": "https://in-toto.io/Statement/v1",
             "subject": [
               {
-                "name": "${PACKAGE_FILE}",
+                "name": "wordpress-${TAG}.${PACKAGE_EXTENSION}",
                 "digest": {
                   "sha256": "${PACKAGE_SHA256}"
                 }
@@ -479,8 +469,7 @@ jobs:
             "predicate": {
               "purl": "pkg:rave/${PACKAGE}/wordpress@${TAG}",
               "metadata": {
-                "releaseNotes": "WordPress core version ${TAG} distributed by ${PACKAGE}",
-                "releaseUrl": "${PACKAGE_URL}",
+                "releaseNotes": "WordPress ${TAG}",
                 "vcs": {
                   "type": "git",
                   "uri": "https://github.com/johnbillion/rave-wordpress",
@@ -496,7 +485,7 @@ jobs:
         uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
         with:
           subject-path: ${{ steps.package-check.outputs.package_file }}
-          subject-name: '${{ inputs.package }}/wordpress@${{ steps.tag.outputs.short }}'
+          subject-name: 'wordpress-${{ steps.tag.outputs.short }}.${{ steps.package-check.outputs.package_extension }}'
           predicate-type: 'https://in-toto.io/attestation/release/v0.1'
           predicate-path: 'release-predicate.json'
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,6 +26,11 @@ jobs:
     permissions: {}
     timeout-minutes: 10
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Prepare tag name
         id: tag
         uses: johnbillion/rave-wordpress/.github/actions/prepare-tag-name@trunk
@@ -407,3 +412,65 @@ jobs:
         if: env.PACKAGE_INCLUDES_AKISMET == 'true'
         run: | #shell
           diff --strip-trailing-cr --recursive --color=always akismet-source akismet-package
+
+      - name: Check for package files
+        id: package-check
+        run: |
+          if [ -f "package.zip" ]; then
+            echo "package_file=package.zip" >> "$GITHUB_OUTPUT"
+          elif [ -f "package.tar.gz" ]; then
+            echo "package_file=package.tar.gz" >> "$GITHUB_OUTPUT"
+          else
+            echo "package_file=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release predicate
+        if: steps.package-check.outputs.package_file != 'false'
+        env:
+          TAG: ${{ steps.tag.outputs.short }}
+          PACKAGE: ${{ inputs.package }}
+          PACKAGE_FILE: ${{ steps.package-check.outputs.package_file }}
+        run: |
+          # Generate SHA256 of package file
+          PACKAGE_SHA256=$(sha256sum "${PACKAGE_FILE}" | cut -d' ' -f1)
+
+          # Get current git commit SHA
+          COMMIT_SHA="${{ github.sha }}"
+
+          # Generate the predicate
+          cat > release-predicate.json <<EOF
+          {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+              {
+                "name": "${PACKAGE_FILE}",
+                "digest": {
+                  "sha256": "${PACKAGE_SHA256}"
+                }
+              }
+            ],
+            "predicateType": "https://in-toto.io/attestation/release/v0.1",
+            "predicate": {
+              "purl": "pkg:rave/${PACKAGE}/wordpress@${TAG}",
+              "metadata": {
+                "releaseNotes": "WordPress core version ${TAG} distributed by ${PACKAGE}",
+                "releaseUrl": "${PACKAGE_URL}",
+                "vcs": {
+                  "type": "git",
+                  "uri": "https://github.com/johnbillion/rave-wordpress",
+                  "revision": "${COMMIT_SHA}"
+                }
+              }
+            }
+          }
+          EOF
+
+          echo "Generated release predicate for ${PACKAGE_FILE}"
+
+      - name: Generate attestation
+        if: steps.package-check.outputs.package_file != 'false'
+        uses: actions/attest@v2.4.0
+        with:
+          subject-path: ${{ steps.package-check.outputs.package_file }}
+          predicate-type: 'https://in-toto.io/attestation/release/v0.1'
+          predicate-path: 'release-predicate.json'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,7 +24,6 @@ jobs:
     name: "${{ inputs.package }}"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write
       attestations: write
     timeout-minutes: 10

--- a/readme.md
+++ b/readme.md
@@ -107,12 +107,12 @@ RAVE generates an [in-toto release attestation](https://github.com/in-toto/attes
 
 ```sh
 wget https://wordpress.org/wordpress-6.8.2.zip
-gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress
+gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress --predicate-type "https://in-toto.io/attestation/release/v0.1"
 ```
 
 ```sh
 wget https://api.aspirecloud.net/download/wordpress-6.8.2.zip
-gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress
+gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress --predicate-type "https://in-toto.io/attestation/release/v0.1"
 ```
 
 ## Does this faciliate WordPress adhering to SLSA?

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,15 @@ wget https://api.aspirecloud.net/download/wordpress-6.8.2.zip
 gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress --predicate-type "https://in-toto.io/attestation/release/v0.1"
 ```
 
+If you want to download and inspect the metadata of an attestation as JSON:
+
+```sh
+file="wordpress-6.8.2.zip"
+hash=$(shasum -a 256 "$file" | cut -d" " -f1)
+gh attestation download "$file" --repo johnbillion/rave-wordpress
+jq -r '.dsseEnvelope.payload' "sha256:${hash}.jsonl" | base64 -d | jq .
+```
+
 ## Does this faciliate WordPress adhering to SLSA?
 
 No. [SLSA](https://slsa.dev/) is a security framework that improves the supply chain resilience of a software package by generating a verifiable build provenance attestation during its build and release process. RAVE _independently reproduces_ the build for WordPress but is not part of the release process itself, therefore it is not appropriate for RAVE to generate an SLSA build provenance attestation.

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,24 @@ The WordPress open source project does not make use of package signing which cou
 
 Therefore, this library has been created to provide a means of verifying that the contents of published packages matches the code built from the official source code repos.
 
+## Attestation
+
+RAVE generates an [in-toto release attestation](https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md) once it's reproduced and verified a given package of WordPress. If you trust RAVE then you can use its attestations to verify a WordPress package that you download, for example using `gh` on the command line:
+
+```sh
+wget https://wordpress.org/wordpress-6.8.2.zip
+gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress
+```
+
+```sh
+wget https://api.aspirecloud.net/download/wordpress-6.8.2.zip
+gh attestation verify wordpress-6.8.2.zip --repo johnbillion/rave-wordpress
+```
+
+## Does this faciliate WordPress adhering to SLSA?
+
+No. [SLSA](https://slsa.dev/) is a security framework that improves the supply chain resilience of a software package by generating a verifiable build provenance attestation during its build and release process. RAVE _independently reproduces_ the build for WordPress but is not part of the release process itself, therefore it is not appropriate for RAVE to generate an SLSA build provenance attestation.
+
 ## License
 
 MIT


### PR DESCRIPTION
This change implements attestations for packages that pass verification. As noted in the updated docs, an SLSA build provenance attestation isn't appropriate but we can do an in-toto release attestation.