### PR TITLE
Remove support for the unofficial-official WordPress image on Docker Hub

### DIFF
--- a/.github/workflows/rave.yml
+++ b/.github/workflows/rave.yml
@@ -206,7 +206,6 @@ jobs:
           - downloads.w.org-zip
           - downloads.w.org-tar
           - github-zip
-          - docker-wordpress
           - wpengine-zip
           - aspirecloud-zip
           - roots-wordpress-full
@@ -273,7 +272,6 @@ jobs:
           - Verify distributed versions
         package:
           - github-zip
-          - docker-wordpress
           - wordpress.org-zip
           - wordpress.org-tar
           - downloads.wordpress.org-zip

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -68,9 +68,6 @@ jobs:
               PACKAGE_URL="https://build.trac.wordpress.org/browser/tags/${TAG_SHORT}?format=zip"
               PACKAGE_INCLUDES_AKISMET=false
               ;;
-            docker-wordpress)
-              PACKAGE_URL="https://hub.docker.com/_/wordpress/tags?name=${TAG_LONG}&ordering=-name"
-              ;;
             wpengine-zip)
               PACKAGE_URL="https://core-updates.wpengine.com/wordpress-${TAG_SHORT}.zip"
               ;;
@@ -264,19 +261,6 @@ jobs:
           unzip -q package.zip -d wordpress
           mv "wordpress/${TAG}" package
 
-      - name: Download Docker image
-        if: inputs.package == 'docker-wordpress'
-        env:
-          TAG: ${{ steps.tag.outputs.long }}
-        run: | #shell
-          yq --null-input '{"services":{"wordpress":{"image":"wordpress:"+strenv(TAG),"container_name":"wordpress","volumes":["./package:/var/www/html:rw"]}}}' > docker-compose.yml
-          docker compose up --quiet-pull -d wordpress
-          docker compose run --rm wordpress -- ls -al /var/www/html
-          docker compose run --rm wordpress -- rm /var/www/html/.htaccess
-          docker compose run --rm wordpress -- rm /var/www/html/wp-config-docker.php
-          docker compose cp wordpress:/var/www/html/wp-content/plugins/akismet akismet-package
-          docker compose run --rm wordpress -- rm -rf /var/www/html/wp-content/plugins/akismet
-
       - name: Download zip from core-updates.wpengine.com
         if: inputs.package == 'wpengine-zip'
         uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@trunk
@@ -375,7 +359,7 @@ jobs:
           rm -rf package/wp-content/plugins/fair-plugin
 
       - name: Extract Akismet
-        if: env.PACKAGE_INCLUDES_AKISMET == 'true' && inputs.package != 'docker-wordpress'
+        if: env.PACKAGE_INCLUDES_AKISMET == 'true'
         run: | #shell
           mv package/wp-content/plugins/akismet akismet-package
 

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -80,46 +80,6 @@ jobs:
             exit 1
           fi
 
-      - name: Verify versions distributed by Docker
-        if: inputs.package == 'docker-wordpress'
-        env:
-          TAG: ${{ steps.tag.outputs.long }}
-        run: |
-          set -e
-
-          page=1
-          all_tags=""
-
-          while [ $page -le 3 ]; do  # Fetch 3 pages to find stable tags
-            url="https://hub.docker.com/v2/repositories/library/wordpress/tags?page_size=100&page=$page"
-            response=$(curl -s -w "\n%{http_code}" "$url")
-            http_code=$(echo "$response" | tail -n1)
-            body=$(echo "$response" | sed '$d')
-
-            if [ "$http_code" != "200" ]; then
-              echo "Error: Docker Hub API returned HTTP $http_code"
-              exit 1
-            fi
-
-            if ! echo "$body" | jq -e . >/dev/null 2>&1; then
-              echo "Error: Docker Hub API returned invalid JSON"
-              exit 1
-            fi
-
-            tags=$(echo "$body" | jq --raw-output '.results[].name')
-
-            all_tags="$all_tags$tags"$'\n'
-
-            page=$((page + 1))
-          done
-
-          latest_tag=$(echo "$all_tags" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
-
-          if [ "$latest_tag" != "$TAG" ]; then
-            echo "Error: Found a newer tag ($latest_tag) than $TAG"
-            exit 1
-          fi
-
       - name: Fetch AspireCloud versions
         if: inputs.package == 'aspirecloud-zip'
         uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@trunk

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,6 @@ RAVE stands for Reproduce And Verify.
 
 ### Unofficial packages
 
-* ✅ `wordpress` image from Docker Hub
 * ✅ `core-updates.wpengine.com` from WPEngine
 * ✅ `api.aspirecloud.net` from AspireCloud
 * ✅ Bundle packages provided by FAIR
@@ -67,7 +66,7 @@ There are several opportunities for the official WordPress package to be tampere
   * Making the backdoor code immediately visible in the diff in the failing workflow
 * [In 2016 Wordfence identified a vulnerability in a webhook mechanism on api.wordpress.org](https://www.wordfence.com/blog/2016/11/hacking-27-web-via-wordpress-auto-update/) and demonstrated that a cracker could theoretically execute a shell command on the api.wordpress.org server. If a cracker exploited this vulnerability to modify an existing release or create a new one then RAVE would have successfully detected this by:
   * Identifying a new version that didn't exist in the source repos
-  * Identifying a modified package that didn't match the code built from the source repos and didn't match the versions published to Packagist and Docker Hub
+  * Identifying a modified package that didn't match the code built from the source repos and didn't match the versions published elsewhere
   * Identifying any attempt to serve an update from an unexpected host name or URL in the update API response
   * Identifying any discrepancies between the published SHA-1 and MD5 hashes, the published checksums, and the offers returned by the update API
 


### PR DESCRIPTION
Fixes #33.

The release process for this package isn't automated so it fails immediately after a new release of WordPress, sometimes for several days. I don't have the capacity to try to work around this.