### PR TITLE
Remove verification for the FAIR bundle

### DIFF
--- a/.github/workflows/rave.yml
+++ b/.github/workflows/rave.yml
@@ -235,9 +235,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # - label: Verify packages
-          #   package: fair-zip
-          #   tag: ${{ needs.versions.outputs.version }}
           - label: Verify latest packages
             package: wordpress.org-zip
             tag: latest
@@ -278,7 +275,6 @@ jobs:
           - downloads.wordpress.org-tar
           - wpengine-zip
           - aspirecloud-zip
-          - fair-zip
           - roots-wordpress-full
           - johnpbloch-wordpress
           - stable-check

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -74,9 +74,6 @@ jobs:
             aspirecloud-zip)
               PACKAGE_URL="https://api.aspirecloud.net/download/wordpress-${TAG_SHORT}.zip"
               ;;
-            fair-zip)
-              PACKAGE_URL="https://github.com/fairpm/fair-plugin/releases/latest/download/wordpress-${TAG_SHORT}-fair.zip"
-              ;;
             roots-wordpress-full)
               PACKAGE_URL="https://packagist.org/packages/roots/wordpress-full#${TAG_SHORT}"
               ;;
@@ -289,20 +286,6 @@ jobs:
           unzip -q package.zip -d wordpress
           mv wordpress/wordpress package
 
-      - name: Download zip from FAIR
-        if: inputs.package == 'fair-zip'
-        uses: johnbillion/rave-wordpress/.github/actions/download-with-retry@trunk
-        with:
-          url: ${{ env.PACKAGE_URL }}
-          output: package.zip
-          version: ${{ steps.tag.outputs.long }}
-
-      - name: Extract FAIR zip
-        if: inputs.package == 'fair-zip'
-        run: | #shell
-          unzip -q package.zip -d wordpress
-          mv wordpress/wordpress package
-
       - name: Download roots/wordpress-full
         if: inputs.package == 'roots-wordpress-full'
         env:
@@ -352,11 +335,6 @@ jobs:
           if [[ "${TAG}" == "latest" ]] || dpkg --compare-versions "${BRANCH}" ge "6.7"; then
             rm -rf source/wp-content/themes/twentytwentytwo
           fi
-
-      - name: Handle known differences in bundled plugins
-        if: inputs.package == 'fair-zip'
-        run: | #shell
-          rm -rf package/wp-content/plugins/fair-plugin
 
       - name: Extract Akismet
         if: env.PACKAGE_INCLUDES_AKISMET == 'true'

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -100,22 +100,6 @@ jobs:
             exit 1
           fi
 
-      - name: Verify versions distributed by FAIR
-        if: inputs.package == 'fair-zip'
-        env:
-          TAG: ${{ steps.tag.outputs.next }}
-        run: |
-          set -e
-          url="https://github.com/fairpm/fair-plugin/releases/latest/download/wordpress-${TAG}-fair.zip"
-          status=$(curl -L -o /dev/null -s -w "%{http_code}" "$url")
-          if [ "$status" == "200" ]; then
-            echo "Error: Found a release for next version ($TAG) at $url"
-            exit 1
-          elif [ "$status" != "404" ]; then
-            echo "Error: Unexpected HTTP status $status when checking for next version ($TAG) at $url"
-            exit 1
-          fi
-
       - name: Verify versions distributed by WPEngine
         if: inputs.package == 'wpengine-zip'
         env:

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,6 @@ RAVE stands for Reproduce And Verify.
 
 * ✅ `core-updates.wpengine.com` from WPEngine
 * ✅ `api.aspirecloud.net` from AspireCloud
-* ✅ Bundle packages provided by FAIR
 * ✅ `roots/wordpress-full` on Packagist
 * ✅ `johnpbloch/wordpress` on Packagist
 


### PR DESCRIPTION
Unfortunately the copy of WordPress that's included in the FAIR release bundle isn't kept up to date with the latest release of WordPress, which makes it impractical to continue verifying. RAVE doesn't currently verify FAIR as a result, so let's just remove it.